### PR TITLE
Feature/refactor cosmos merging

### DIFF
--- a/src/EPR.RegulatorService.Facade.API/Filters/Swashbuckle/ExampleRequestsFilter.cs
+++ b/src/EPR.RegulatorService.Facade.API/Filters/Swashbuckle/ExampleRequestsFilter.cs
@@ -2,9 +2,11 @@
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Diagnostics.CodeAnalysis;
 
 namespace EPR.RegulatorService.Facade.API.Filters.Swashbuckle
 {
+    [ExcludeFromCodeCoverage]
     public class ExampleRequestsFilter : IOperationFilter
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)

--- a/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
@@ -80,10 +80,8 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
                 var cosmosItems = deltaRegistrationDecisionsResponse.Where(x => !string.IsNullOrWhiteSpace(x.AppReferenceNumber)
                                   && x.AppReferenceNumber.Equals(item?.ApplicationReferenceNumber, StringComparison.OrdinalIgnoreCase)).OrderBy(x => x.Created);
                 var regulatorDecisions = cosmosItems.Where(x => x.Type.Equals("RegulatorRegistrationDecision", StringComparison.OrdinalIgnoreCase)).OrderBy(x => x.Created).ToList();
-                //var producerSubmissions = cosmosItems.Where(x => x.Type.Equals("RegistrationApplicationSubmitted", StringComparison.OrdinalIgnoreCase)).Select(x => x.Created);
 
                 ProcessRegulatorDecisions(item, regulatorDecisions);
-                //ProcessProducerSubmissions(item, producerSubmissions);
             }
         }        
 
@@ -118,19 +116,6 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
                 }
             }
         }
-
-        //private static void ProcessProducerSubmissions(OrganisationRegistrationSubmissionSummaryResponse item, IEnumerable<DateTime> producerSubmissions)
-        //{
-        //    foreach (var cosmosDate in producerSubmissions)
-        //    {
-        //        if (cosmosDate > item.RegulatorDecisionDate && (!item.IsResubmission && item.SubmissionStatus == RegistrationSubmissionStatus.Granted))
-        //        {
-        //            item.IsResubmission = true;
-        //            item.ResubmissionDate = cosmosDate;
-        //            item.ResubmissionStatus = RegistrationSubmissionStatus.Pending;
-        //        }
-        //    }
-        //}
 
         public static void AssignProducerDetails(RegistrationSubmissionOrganisationDetailsResponse item, AbstractCosmosSubmissionEvent? cosmosItem)
         {

--- a/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
@@ -80,10 +80,10 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
                 var cosmosItems = deltaRegistrationDecisionsResponse.Where(x => !string.IsNullOrWhiteSpace(x.AppReferenceNumber)
                                   && x.AppReferenceNumber.Equals(item?.ApplicationReferenceNumber, StringComparison.OrdinalIgnoreCase)).OrderBy(x => x.Created);
                 var regulatorDecisions = cosmosItems.Where(x => x.Type.Equals("RegulatorRegistrationDecision", StringComparison.OrdinalIgnoreCase)).OrderBy(x => x.Created).ToList();
-                var producerSubmissions = cosmosItems.Where(x => x.Type.Equals("RegistrationApplicationSubmitted", StringComparison.OrdinalIgnoreCase)).Select(x => x.Created);
+                //var producerSubmissions = cosmosItems.Where(x => x.Type.Equals("RegistrationApplicationSubmitted", StringComparison.OrdinalIgnoreCase)).Select(x => x.Created);
 
                 ProcessRegulatorDecisions(item, regulatorDecisions);
-                ProcessProducerSubmissions(item, producerSubmissions);
+                //ProcessProducerSubmissions(item, producerSubmissions);
             }
         }        
 
@@ -119,18 +119,18 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
             }
         }
 
-        private static void ProcessProducerSubmissions(OrganisationRegistrationSubmissionSummaryResponse item, IEnumerable<DateTime> producerSubmissions)
-        {
-            foreach (var cosmosDate in producerSubmissions)
-            {
-                if (cosmosDate > item.RegulatorDecisionDate && (!item.IsResubmission && item.SubmissionStatus == RegistrationSubmissionStatus.Granted))
-                {
-                    item.IsResubmission = true;
-                    item.ResubmissionDate = cosmosDate;
-                    item.ResubmissionStatus = RegistrationSubmissionStatus.Pending;
-                }
-            }
-        }
+        //private static void ProcessProducerSubmissions(OrganisationRegistrationSubmissionSummaryResponse item, IEnumerable<DateTime> producerSubmissions)
+        //{
+        //    foreach (var cosmosDate in producerSubmissions)
+        //    {
+        //        if (cosmosDate > item.RegulatorDecisionDate && (!item.IsResubmission && item.SubmissionStatus == RegistrationSubmissionStatus.Granted))
+        //        {
+        //            item.IsResubmission = true;
+        //            item.ResubmissionDate = cosmosDate;
+        //            item.ResubmissionStatus = RegistrationSubmissionStatus.Pending;
+        //        }
+        //    }
+        //}
 
         public static void AssignProducerDetails(RegistrationSubmissionOrganisationDetailsResponse item, AbstractCosmosSubmissionEvent? cosmosItem)
         {

--- a/src/EPR.RegulatorService.Facade.UnitTests/API/Controllers/OrganisationRegistrationSubmissionsControllerTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/API/Controllers/OrganisationRegistrationSubmissionsControllerTests.cs
@@ -128,7 +128,7 @@ public class OrganisationRegistrationSubmissionsControllerTests
     }
 
     [TestMethod]
-    public async Task CreateRegulatorSubmissionDecisionEvent_Should_Fetach_UserId_from_HttpContext_When_Input_Reuqest_UserId_Is_Null()
+    public async Task CreateRegulatorSubmissionDecisionEvent_Should_Fetch_UserId_from_HttpContext_When_Input_Request_UserId_Is_Null()
     {
         // Arrange
         var request = new RegulatorDecisionCreateRequest
@@ -371,8 +371,6 @@ public class OrganisationRegistrationSubmissionsControllerTests
         statusCodeResult?.StatusCode.Should().Be(200);
         _commonDataServiceMock.Verify(r => r.GetOrganisationRegistrationSubmissionDetails(submissionId), Times.AtMostOnce);
     }
-
-
 
 
     [TestMethod()]

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/RegistrationSubmission/OrganisationRegistrationSubmissionServiceTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/RegistrationSubmission/OrganisationRegistrationSubmissionServiceTests.cs
@@ -637,84 +637,6 @@ public class OrganisationRegistrationSubmissionServiceTests
         Assert.AreEqual(RegistrationSubmissionStatus.Cancelled, item.SubmissionStatus, "Should update to the newer event's Decision.");
     }
 
-    [Ignore("TODO::Revisit business logic")]
-    [TestMethod]
-    public void ProducerCommentsWithoutRegulatorCommentDate()
-    {
-        // Arrange
-        var commentDate = DateTime.UtcNow;
-        var requestedList = new PaginatedResponse<OrganisationRegistrationSubmissionSummaryResponse>
-        {
-            items = new List<OrganisationRegistrationSubmissionSummaryResponse>
-                {
-                    new() {
-                        ApplicationReferenceNumber = "APP123",
-                        RegulatorDecisionDate = null,
-                        SubmissionStatus = RegistrationSubmissionStatus.Granted
-                    }
-                }
-        };
-
-        var deltaRegistrationDecisionsResponse = new List<AbstractCosmosSubmissionEvent>
-            {
-                new() {
-                    AppReferenceNumber = "APP123",
-                    Created = commentDate,
-                    Type = "RegistrationApplicationSubmitted"
-                }
-            };
-
-        // Act
-        MergeCosmosUpdates(deltaRegistrationDecisionsResponse, requestedList);
-
-        // Assert
-        var item = requestedList.items[0];
-        Assert.AreEqual(commentDate, item.SubmissionDate, "SubmissionDate should match the event's Created date.");
-        // RegulatorDecisionDate is null, SubmissionDate > null condition is irrelevant, but code sets SubmissionStatus to Updated if ProducerCommentDate > RegulatorCommentDate
-        // Since RegulatorDecisionDate is null, we can consider SubmissionDate > null logically true for this code's logic.
-        Assert.AreEqual(RegistrationSubmissionStatus.Granted, item.SubmissionStatus, "SubmissionStatus should change to Updated due to producer comment.");
-    }
-
-    [Ignore("TODO::Revisit business logic")]
-    [TestMethod]
-    public void ProducerCommentsWhenRegulatorCommentDateNotNullAndProducerLater()
-    {
-        // Arrange
-        var regulatorDate = DateTime.UtcNow.AddHours(-2);
-        var producerDate = DateTime.UtcNow;
-
-        var requestedList = new PaginatedResponse<OrganisationRegistrationSubmissionSummaryResponse>
-        {
-            items = new List<OrganisationRegistrationSubmissionSummaryResponse>
-                {
-                    new() {
-                        ApplicationReferenceNumber = "APP123",
-                        RegulatorDecisionDate = regulatorDate,
-                        SubmissionStatus = RegistrationSubmissionStatus.Granted
-                    }
-                }
-        };
-
-        var deltaRegistrationDecisionsResponse = new List<AbstractCosmosSubmissionEvent>
-            {
-                new() {
-                    AppReferenceNumber = "APP123",
-                    Created = producerDate,
-                    Type = "RegistrationApplicationSubmitted"
-                }
-            };
-
-        // Act
-        MergeCosmosUpdates(deltaRegistrationDecisionsResponse, requestedList);
-
-        // Assert
-        var item = requestedList.items[0];
-        Assert.AreEqual(producerDate, item.SubmissionDate, "SubmissionDate should match the event.");
-        // Since ProducerCommentDate > RegulatorCommentDate, SubmissionStatus should become Updated.
-        Assert.AreEqual(RegistrationSubmissionStatus.Granted, item.SubmissionStatus, "Status should update to Updated.");
-    }
-
-    [Ignore("TODO::Revisit business logic")]
     [TestMethod]
     public void ProducerCommentsWhenRegulatorCommentDateNewerThanProducer()
     {
@@ -729,6 +651,7 @@ public class OrganisationRegistrationSubmissionServiceTests
                     new() {
                         ApplicationReferenceNumber = "APP123",
                         RegulatorDecisionDate = regulatorDate,
+                        SubmissionDate = producerDate,
                         SubmissionStatus = RegistrationSubmissionStatus.Granted
                     }
                 }
@@ -802,6 +725,7 @@ public class OrganisationRegistrationSubmissionServiceTests
         Assert.AreEqual(RegistrationSubmissionStatus.Refused, item.SubmissionStatus, "Should reflect the later event's Decision.");
     }
 
+    [Ignore("Logic to indicate Resubmission from Cosmos is invalid as the Resubmitted data may not be avialable in Synapse")]
     [TestMethod]
     public void MultipleProducerRegistrationsUpdatesResubmissionStatus()
     {


### PR DESCRIPTION
The changes here are to remove the logic of synchronising 'ProducerComments' - they are not comments but resubmissions.

Because of the delays between Cosmos and Synapse - telling the Regulator that an resubmission is present could lead to logical errors and support calls.
