### PR TITLE
Prevent Facade from returning 404 when no submission loaded

### DIFF
--- a/src/EPR.RegulatorService.Facade.API/Controllers/OrganisationRegistrationSubmissionsController.cs
+++ b/src/EPR.RegulatorService.Facade.API/Controllers/OrganisationRegistrationSubmissionsController.cs
@@ -167,7 +167,7 @@ public class OrganisationRegistrationSubmissionsController(
 
             if (result is null)
             {
-                return NotFound();
+                return NoContent();
             }
 
             return Ok(result);


### PR DESCRIPTION
When loading a submission that doesn't load - the facade returns a 404 - which is spurious error logging because of the failure code.  It has been changed to NoContent.