### PR TITLE
Updated Validation logic for FileId and Cancellation Events

### DIFF
--- a/src/EPR.RegulatorService.Facade.API/Controllers/OrganisationRegistrationSubmissionsController.cs
+++ b/src/EPR.RegulatorService.Facade.API/Controllers/OrganisationRegistrationSubmissionsController.cs
@@ -32,7 +32,8 @@ public class OrganisationRegistrationSubmissionsController(
             }
             else if (request.IsResubmission 
                     && (string.IsNullOrWhiteSpace(request.ExistingRegRefNumber)
-                    || string.IsNullOrWhiteSpace(request.FileId)))
+                        || 
+                        (string.IsNullOrWhiteSpace(request.FileId)) && request.Status != Core.Enums.RegistrationSubmissionStatus.Cancelled))
             {
                 if (string.IsNullOrWhiteSpace(request.ExistingRegRefNumber))
                     ModelState.AddModelError(nameof(request.ExistingRegRefNumber), "ExistingRegRefNumber is required for resubmission");
@@ -42,9 +43,9 @@ public class OrganisationRegistrationSubmissionsController(
                 return ValidationProblem(ModelState);
             }
 
-            var serviceResult =
-                await organisationRegistrationSubmissionService.HandleCreateRegulatorDecisionSubmissionEvent(request,
-                    GetUserId(request.UserId));
+                var serviceResult =
+                    await organisationRegistrationSubmissionService.HandleCreateRegulatorDecisionSubmissionEvent(request,
+                        GetUserId(request.UserId));
 
             if (serviceResult.IsSuccessStatusCode)
             {

--- a/src/EPR.RegulatorService.Facade.UnitTests/API/Controllers/OrganisationRegistrationSubmissionsControllerTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/API/Controllers/OrganisationRegistrationSubmissionsControllerTests.cs
@@ -256,6 +256,41 @@ public class OrganisationRegistrationSubmissionsControllerTests
     }
 
     [TestMethod]
+    public async Task Should_Allow_Null_FileId_When_Status_Is_Cancellation_And_Submission_Is_Resubmission()
+    {
+        // Arrange
+        var request = new RegulatorDecisionCreateRequest
+        {
+            OrganisationId = Guid.NewGuid(),
+            Status = RegistrationSubmissionStatus.Cancelled,
+            SubmissionId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Comments = "comments",
+            FileId = null,
+            ExistingRegRefNumber = "EXISTING",
+            IsResubmission = true
+        };
+
+        var handlerResponse =
+        _fixture
+            .Build<HttpResponseMessage>()
+            .With(x => x.StatusCode, HttpStatusCode.Created)
+            .With(x => x.Content, new StringContent(_fixture.Create<string>()))
+            .Create();
+        
+        _submissionsServiceMock.Setup(r => r.CreateSubmissionEvent(
+            It.IsAny<Guid>(), It.IsAny<RegistrationSubmissionDecisionEvent>(), It.IsAny<Guid>())).ReturnsAsync(handlerResponse);
+
+        // Act
+        var result = await _sut.CreateRegulatorSubmissionDecisionEvent(request) as ObjectResult;
+
+        // Assert
+        result.Should().NotBeNull();
+        _submissionsServiceMock.Verify(r => r.CreateSubmissionEvent(
+            It.IsAny<Guid>(), It.IsAny<RegistrationSubmissionDecisionEvent>(), It.IsAny<Guid>()), Times.AtMostOnce);
+    }
+
+    [TestMethod]
     [DataRow(HttpStatusCode.InternalServerError)]
     [DataRow(HttpStatusCode.BadGateway)]
     [DataRow(HttpStatusCode.ServiceUnavailable)]


### PR DESCRIPTION
Amended logic to ensure that the FileId can be null when a Cancellation event is sent for a Resubmitted registration.