### PR TITLE
Changes to

### DIFF
--- a/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistationSubmissionService_Synchronisation.cs
@@ -130,6 +130,10 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
                 RegistrationSubmissionStatus.Refused => RegistrationSubmissionStatus.Rejected,
                 _ => item.ResubmissionStatus
             };
+            if ( resubmissionStatus == RegistrationSubmissionStatus.Cancelled)
+            {
+                item.SubmissionStatus = RegistrationSubmissionStatus.Cancelled;
+            }
         }
 
         private static void ProcessStandardDecision(
@@ -137,10 +141,16 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
             AbstractCosmosSubmissionEvent cosmosItem)
         {
             item.SubmissionStatus = Enum.Parse<RegistrationSubmissionStatus>(cosmosItem.Decision);
+            item.RegulatorDecisionDate = cosmosItem.Created;
+            
             item.StatusPendingDate = cosmosItem.DecisionDate;
             if (!string.IsNullOrWhiteSpace(cosmosItem.RegistrationReferenceNumber))
             {
                 item.RegistrationReferenceNumber = cosmosItem.RegistrationReferenceNumber;
+            }
+            if(cosmosItem.Decision == "Granted")
+            {
+                item.RegistrationDate = cosmosItem.Created;
             }
         }
 
@@ -178,6 +188,11 @@ namespace EPR.RegulatorService.Facade.Core.Services.RegistrationSubmission
                     item.StatusPendingDate = cosmosItem.DecisionDate;
                     item.RegistrationReferenceNumber = string.IsNullOrWhiteSpace(cosmosItem.RegistrationReferenceNumber) ? item.RegistrationReferenceNumber : cosmosItem.RegistrationReferenceNumber;
                     item.SubmissionDetails.Status = item.SubmissionStatus;
+
+                    if ( cosmosItem.Decision == "Granted")
+                    {
+                        item.RegistrationDate = item.SubmissionDetails.RegistrationDate = cosmosItem.Created;
+                    }
                 }
             }
             else

--- a/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistrationSubmissionService.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/RegistrationSubmission/OrganisationRegistrationSubmissionService.cs
@@ -53,6 +53,16 @@ public partial class OrganisationRegistrationSubmissionService(
                 MergeCosmosUpdates(deltaRegistrationDecisionsResponse, requestedList);
             }
 
+            requestedList.items = [.. requestedList.items.OrderBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Cancelled)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Refused)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Granted && !x.IsResubmission )
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Queried)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Granted && x.ResubmissionStatus == RegistrationSubmissionStatus.Rejected)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Granted && x.ResubmissionStatus == RegistrationSubmissionStatus.Accepted)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Granted && x.ResubmissionStatus == RegistrationSubmissionStatus.Pending)
+                .ThenBy(x => x.SubmissionStatus == RegistrationSubmissionStatus.Pending)
+                .ThenByDescending(x => x.SubmissionDate)];
+
             return requestedList;
         }
         catch (Exception ex)


### PR DESCRIPTION
* OrganisationRegistrationSubmissionService
* OrganisationRegistrationSubmissionService_Synchronisation

Ensured that RegistrationDate is applied correctly.  
List-View Cancelled Resubmissions statuses are updated with Cosmos data 
Sorted results according to business requirements, preventing interspersal of statuses in the list page when a regulator updates a status
Ensuring date parity between details and list view when items are updated

To test with 550052/54 and 557553