### PR TITLE
Amcr 136 handle closed loop recycling registration fee

### DIFF
--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
@@ -10,6 +10,7 @@ public class CsoMembershipDetailsDto
     public string MemberType { get; set; }
     public bool IsOnlineMarketPlace { get; set; }
     public bool IsLateFeeApplicable { get; set; }
+    public bool? IsClosedLoopRecycler { get; set; }
     public int NumberOfSubsidiaries { get; set; }
 
     [JsonPropertyName("NumberOfSubsidiariesOnlineMarketPlace")]

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
@@ -11,7 +11,7 @@ public class CsoMembershipDetailsDto
     public bool IsOnlineMarketPlace { get; set; }
     public bool IsLateFeeApplicable { get; set; }
 
-    public bool? IsClosedLoopRecycling { get; set; }
+    public bool? IsClosedLoopRecycler { get; set; }
     public int NumberOfSubsidiaries { get; set; }
 
     [JsonPropertyName("NumberOfSubsidiariesOnlineMarketPlace")]

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
@@ -10,7 +10,8 @@ public class CsoMembershipDetailsDto
     public string MemberType { get; set; }
     public bool IsOnlineMarketPlace { get; set; }
     public bool IsLateFeeApplicable { get; set; }
-    public bool? IsClosedLoopRecycler { get; set; }
+
+    public bool? IsClosedLoopRecycling { get; set; }
     public int NumberOfSubsidiaries { get; set; }
 
     [JsonPropertyName("NumberOfSubsidiariesOnlineMarketPlace")]

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.Json.Serialization;
 
 namespace EPR.RegulatorService.Facade.Core.Models.Responses.OrganisationRegistrations.CommonData;
 
@@ -43,7 +44,8 @@ public class OrganisationRegistrationDetailsDto
     public string? RegulatorResubmissionDecisionDate { get; set; }
     public Guid? RegulatorUserId { get; set; }
     
-    public bool IsClosedLoopRecycler { get; set; }
+    [JsonPropertyName("isClosedLoopRecycler")]
+    public bool? IsClosedLoopRecycling { get; set; }
     
     // organisation details
     public string? CompaniesHouseNumber { get; set; }
@@ -159,7 +161,7 @@ public class OrganisationRegistrationDetailsDto
 
         response.NationId = dto.NationId;
         response.NationCode = dto.NationCode;
-        response.IsClosedLoopRecycler = dto.IsClosedLoopRecycler;
+        response.IsClosedLoopRecycling = dto.IsClosedLoopRecycling ?? false;
         
         response.RegulatorComments = dto.RegulatorComment ?? string.Empty;
         response.ProducerComments = dto.ProducerComment ?? string.Empty;

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
@@ -42,7 +42,9 @@ public class OrganisationRegistrationDetailsDto
     public string? ProducerCommentDate { get; set; }
     public string? RegulatorResubmissionDecisionDate { get; set; }
     public Guid? RegulatorUserId { get; set; }
-
+    
+    public bool IsClosedLoopRecycler { get; set; }
+    
     // organisation details
     public string? CompaniesHouseNumber { get; set; }
     public string? BuildingName { get; set; }
@@ -157,7 +159,8 @@ public class OrganisationRegistrationDetailsDto
 
         response.NationId = dto.NationId;
         response.NationCode = dto.NationCode;
-
+        response.IsClosedLoopRecycler = dto.IsClosedLoopRecycler;
+        
         response.RegulatorComments = dto.RegulatorComment ?? string.Empty;
         response.ProducerComments = dto.ProducerComment ?? string.Empty;
         response.RegulatorDecisionDate = convertDateTime(dto.RegulatorDecisionDate);

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text.Json.Serialization;
 
 namespace EPR.RegulatorService.Facade.Core.Models.Responses.OrganisationRegistrations.CommonData;
 
@@ -43,10 +42,9 @@ public class OrganisationRegistrationDetailsDto
     public string? ProducerCommentDate { get; set; }
     public string? RegulatorResubmissionDecisionDate { get; set; }
     public Guid? RegulatorUserId { get; set; }
-    
-    [JsonPropertyName("isClosedLoopRecycler")]
-    public bool? IsClosedLoopRecycling { get; set; }
-    
+
+    public bool? IsClosedLoopRecycler { get; set; }
+
     // organisation details
     public string? CompaniesHouseNumber { get; set; }
     public string? BuildingName { get; set; }
@@ -161,7 +159,7 @@ public class OrganisationRegistrationDetailsDto
 
         response.NationId = dto.NationId;
         response.NationCode = dto.NationCode;
-        response.IsClosedLoopRecycling = dto.IsClosedLoopRecycling ?? false;
+        response.IsClosedLoopRecycler = dto.IsClosedLoopRecycler ?? false;
         
         response.RegulatorComments = dto.RegulatorComment ?? string.Empty;
         response.ProducerComments = dto.ProducerComment ?? string.Empty;

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
@@ -32,7 +32,7 @@ public class RegistrationSubmissionOrganisationDetailsFacadeResponse
     public DateTime? StatusPendingDate { get; set; }
     public bool IsResubmission { get; set; }
     public DateTime? RegistrationDate { get; set; }
-    public bool IsClosedLoopRecycler { get; set; }
+    public bool IsClosedLoopRecycling { get; set; }
     public string? RegulatorComments { get; set; } = string.Empty;
     public string? ProducerComments { get; set; } = string.Empty;
     public string ApplicationReferenceNumber { get; set; } = string.Empty;

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
@@ -32,6 +32,7 @@ public class RegistrationSubmissionOrganisationDetailsFacadeResponse
     public DateTime? StatusPendingDate { get; set; }
     public bool IsResubmission { get; set; }
     public DateTime? RegistrationDate { get; set; }
+    public bool IsClosedLoopRecycler { get; set; }
     public string? RegulatorComments { get; set; } = string.Empty;
     public string? ProducerComments { get; set; } = string.Empty;
     public string ApplicationReferenceNumber { get; set; } = string.Empty;

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
@@ -32,7 +32,7 @@ public class RegistrationSubmissionOrganisationDetailsFacadeResponse
     public DateTime? StatusPendingDate { get; set; }
     public bool IsResubmission { get; set; }
     public DateTime? RegistrationDate { get; set; }
-    public bool IsClosedLoopRecycling { get; set; }
+    public bool IsClosedLoopRecycler { get; set; }
     public string? RegulatorComments { get; set; } = string.Empty;
     public string? ProducerComments { get; set; } = string.Empty;
     public string ApplicationReferenceNumber { get; set; } = string.Empty;

--- a/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
@@ -154,10 +154,10 @@ public class CommonDataService(
         {
             try
             {
-                List<CsoMembershipDetailsDto> csoDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(jsonObject.CSOJson);
+                List<CsoMembershipDetailsDto> csoDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(jsonObject.CSOJson, _deserialisationOptions);
                 foreach (var member in csoDetails)
                 {
-                    member.IsClosedLoopRecycler ??= jsonObject.IsClosedLoopRecycler;
+                    member.IsClosedLoopRecycling ??= jsonObject.IsClosedLoopRecycling;
                 }
                 objRet.CsoMembershipDetails = csoDetails;
             }

--- a/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
@@ -155,6 +155,10 @@ public class CommonDataService(
             try
             {
                 List<CsoMembershipDetailsDto> csoDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(jsonObject.CSOJson);
+                foreach (var member in csoDetails)
+                {
+                    member.IsClosedLoopRecycler ??= jsonObject.IsClosedLoopRecycler;
+                }
                 objRet.CsoMembershipDetails = csoDetails;
             }
             catch (Exception ex)

--- a/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
@@ -157,7 +157,7 @@ public class CommonDataService(
                 List<CsoMembershipDetailsDto> csoDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(jsonObject.CSOJson, _deserialisationOptions);
                 foreach (var member in csoDetails)
                 {
-                    member.IsClosedLoopRecycling ??= jsonObject.IsClosedLoopRecycling;
+                    member.IsClosedLoopRecycler ??= jsonObject.IsClosedLoopRecycler;
                 }
                 objRet.CsoMembershipDetails = csoDetails;
             }

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using EPR.RegulatorService.Facade.Core.Models.Responses.OrganisationRegistrations;
+using EPR.RegulatorService.Facade.Core.Models.Responses.OrganisationRegistrations.CommonData;
+using FluentAssertions;
+
+namespace EPR.RegulatorService.Facade.UnitTests.Core.Models;
+
+[TestClass]
+public class OrganisationRegistrationDetailsDtoTests
+{
+    private static readonly JsonSerializerOptions DeserialisationOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [TestMethod]
+    public void Deserialize_FromCommonDataApi_MapsIsClosedLoopRecyclerToIsClosedLoopRecycling()
+    {
+        const string json = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "Test Org",
+              "organisationReference": "100001",
+              "applicationReferenceNumber": "REG-2025-001",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "isClosedLoopRecycler": true,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": false,
+              "organisationSize": "Large",
+              "organisationType": "Direct",
+              "registrationJourney": "LargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG"
+            }
+            """;
+
+        var dto = JsonSerializer.Deserialize<OrganisationRegistrationDetailsDto>(json, DeserialisationOptions);
+
+        dto.Should().NotBeNull();
+        dto!.IsClosedLoopRecycling.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ImplicitOperator_MapsIsClosedLoopRecyclingToFacadeResponse()
+    {
+        var dto = new OrganisationRegistrationDetailsDto
+        {
+            SubmissionId = Guid.NewGuid(),
+            OrganisationId = Guid.NewGuid(),
+            OrganisationName = "Test",
+            OrganisationReference = "100001",
+            ApplicationReferenceNumber = "REG-2025-001",
+            SubmissionStatus = "Granted",
+            SubmittedDateTime = "2025-01-11T10:30:00Z",
+            SubmissionPeriod = "2025",
+            RelevantYear = 2025,
+            ResubmissionStatus = "Pending",
+            IsComplianceScheme = false,
+            OrganisationSize = "Large",
+            OrganisationType = "Direct",
+            RegistrationJourney = "LargeProducer",
+            NationId = 1,
+            NationCode = "GB-ENG",
+            IsClosedLoopRecycling = true
+        };
+
+        var response = (RegistrationSubmissionOrganisationDetailsFacadeResponse)dto;
+
+        response.IsClosedLoopRecycling.Should().BeTrue();
+    }
+}

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
@@ -14,7 +14,7 @@ public class OrganisationRegistrationDetailsDtoTests
     };
 
     [TestMethod]
-    public void Deserialize_FromCommonDataApi_MapsIsClosedLoopRecyclerToIsClosedLoopRecycling()
+    public void Deserialize_FromCommonDataApi_Maps_IsClosedLoopRecycler_FromJson()
     {
         const string json = """
             {
@@ -43,11 +43,11 @@ public class OrganisationRegistrationDetailsDtoTests
         var dto = JsonSerializer.Deserialize<OrganisationRegistrationDetailsDto>(json, DeserialisationOptions);
 
         dto.Should().NotBeNull();
-        dto!.IsClosedLoopRecycling.Should().BeTrue();
+        dto!.IsClosedLoopRecycler.Should().BeTrue();
     }
 
     [TestMethod]
-    public void ImplicitOperator_MapsIsClosedLoopRecyclingToFacadeResponse()
+    public void ImplicitOperator_Maps_IsClosedLoopRecycler_ToFacadeResponse()
     {
         var dto = new OrganisationRegistrationDetailsDto
         {
@@ -67,11 +67,11 @@ public class OrganisationRegistrationDetailsDtoTests
             RegistrationJourney = "LargeProducer",
             NationId = 1,
             NationCode = "GB-ENG",
-            IsClosedLoopRecycling = true
+            IsClosedLoopRecycler = true
         };
 
         var response = (RegistrationSubmissionOrganisationDetailsFacadeResponse)dto;
 
-        response.IsClosedLoopRecycling.Should().BeTrue();
+        response.IsClosedLoopRecycler.Should().BeTrue();
     }
 }

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
@@ -269,6 +269,87 @@ public class CommonDataServiceTests
     }
 
     [TestMethod]
+    public async Task Should_map_isClosedLoopRecycler_from_common_data_and_apply_cso_member_fallback()
+    {
+        var submissionId = Guid.NewGuid();
+        _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
+
+        const string commonDataJson = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "CSO Producer",
+              "organisationReference": "100002",
+              "applicationReferenceNumber": "REG-2025-002",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "isClosedLoopRecycler": true,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": true,
+              "organisationSize": "Large",
+              "organisationType": "compliance",
+              "registrationJourney": "CsoLargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG",
+              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
+            }
+            """;
+
+        SetupApiSuccessCall(commonDataJson);
+
+        var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
+
+        results.Should().NotBeNull();
+        results!.IsClosedLoopRecycling.Should().BeTrue();
+        results.CsoMembershipDetails.Should().HaveCount(1);
+        results.CsoMembershipDetails![0].IsClosedLoopRecycling.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Should_not_override_explicit_false_cso_member_closed_loop_flag()
+    {
+        var submissionId = Guid.NewGuid();
+        _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
+
+        const string commonDataJson = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "CSO Producer",
+              "organisationReference": "100002",
+              "applicationReferenceNumber": "REG-2025-002",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "isClosedLoopRecycler": true,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": true,
+              "organisationSize": "Large",
+              "organisationType": "compliance",
+              "registrationJourney": "CsoLargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG",
+              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isClosedLoopRecycling\":false,\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
+            }
+            """;
+
+        SetupApiSuccessCall(commonDataJson);
+
+        var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
+
+        results.Should().NotBeNull();
+        results!.IsClosedLoopRecycling.Should().BeTrue();
+        results.CsoMembershipDetails![0].IsClosedLoopRecycling.Should().BeFalse();
+    }
+
+    [TestMethod]
     public async Task Should_Return_Null_When_HTTP_Results_AreEmpty()
     {
         var submissionId = Guid.NewGuid();

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
@@ -269,7 +269,7 @@ public class CommonDataServiceTests
     }
 
     [TestMethod]
-    public async Task Should_map_isClosedLoopRecycler_from_common_data_and_apply_cso_member_fallback()
+    public async Task Should_map_common_data_IsClosedLoopRecycler_and_apply_cso_member_fallback()
     {
         var submissionId = Guid.NewGuid();
         _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
@@ -304,9 +304,9 @@ public class CommonDataServiceTests
         var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
 
         results.Should().NotBeNull();
-        results!.IsClosedLoopRecycling.Should().BeTrue();
+        results!.IsClosedLoopRecycler.Should().BeTrue();
         results.CsoMembershipDetails.Should().HaveCount(1);
-        results.CsoMembershipDetails![0].IsClosedLoopRecycling.Should().BeTrue();
+        results.CsoMembershipDetails![0].IsClosedLoopRecycler.Should().BeTrue();
     }
 
     [TestMethod]
@@ -336,7 +336,7 @@ public class CommonDataServiceTests
               "registrationJourney": "CsoLargeProducer",
               "nationId": 1,
               "nationCode": "GB-ENG",
-              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isClosedLoopRecycling\":false,\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
+              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isClosedLoopRecycler\":false,\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
             }
             """;
 
@@ -345,8 +345,8 @@ public class CommonDataServiceTests
         var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
 
         results.Should().NotBeNull();
-        results!.IsClosedLoopRecycling.Should().BeTrue();
-        results.CsoMembershipDetails![0].IsClosedLoopRecycling.Should().BeFalse();
+        results!.IsClosedLoopRecycler.Should().BeTrue();
+        results.CsoMembershipDetails![0].IsClosedLoopRecycler.Should().BeFalse();
     }
 
     [TestMethod]

--- a/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
+++ b/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
@@ -63,18 +63,24 @@ namespace IntegrationTests.Features
         result.GetProperty("totalItems").GetInt32().Should().Be(1);
     }
 
-    [Fact]
-    public async Task GetRegistrationSubmissionDetails_ReturnsSuccess_WithValidSubmissionId()
-    {
-        // Arrange
-        var submissionId = Guid.Parse("0163A629-7780-445F-B00E-1898546BDF0C");
-        var organisationId = Guid.Parse("EE29CFAE-81AB-435F-8759-7285959530DB");
+    private sealed record OrganisationRegistrationDetailsMockVariation(
+        bool? IsClosedLoopRecycler,
+        bool IsComplianceScheme,
+        string OrganisationType,
+        string RegistrationJourney,
+        string OrganisationName,
+        string? OrganisationSize,
+        string? CompaniesHouseNumber,
+        string? CsoJson);
 
-        var mockData = new
+    // Common Data organisation-registration payload shape (camelCase anon-type properties match WireMock JSON).
+    private static object CreateOrganisationRegistrationDetailsMock(Guid submissionId, Guid organisationId, OrganisationRegistrationDetailsMockVariation variation)
+    {
+        return new
         {
             submissionId = submissionId.ToString(),
             organisationId = organisationId.ToString(),
-            organisationName = "Compliance Scheme Ltd",
+            organisationName = variation.OrganisationName,
             organisationReference = "100001",
             applicationReferenceNumber = "REG-2025-001",
             registrationReferenceNumber = (string?)null,
@@ -89,10 +95,10 @@ namespace IntegrationTests.Features
             registrationDate = (string?)null,
             resubmissionDate = (string?)null,
             resubmissionFileId = (string?)null,
-            isComplianceScheme = true,
-            organisationSize = (string?)null,
-            organisationType = "compliance",
-            registrationJourney = "CsoLargeProducer",
+            isComplianceScheme = variation.IsComplianceScheme,
+            organisationSize = variation.OrganisationSize,
+            organisationType = variation.OrganisationType,
+            registrationJourney = variation.RegistrationJourney,
             nationId = 1,
             nationCode = "GB-ENG",
             regulatorComment = "",
@@ -101,7 +107,8 @@ namespace IntegrationTests.Features
             producerCommentDate = (string?)null,
             regulatorResubmissionDecisionDate = (string?)null,
             regulatorUserId = (string?)null,
-            companiesHouseNumber = "CS123456",
+            isClosedLoopRecycler = variation.IsClosedLoopRecycler,
+            companiesHouseNumber = variation.CompaniesHouseNumber,
             buildingName = "Test Building",
             subBuildingName = "1",
             buildingNumber = "1",
@@ -131,8 +138,30 @@ namespace IntegrationTests.Features
             brandsFileId = (string?)null,
             brandsFileName = (string?)null,
             brandsBlobName = (string?)null,
-            csoJson = "[{\"memberId\":\"100001\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"NumberOfSubsidiariesOnlineMarketPlace\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-10T07:24:00\",\"submissionPeriodDescription\":\"January to December 2025\"}]"
+            csoJson = variation.CsoJson
         };
+    }
+
+    [Fact]
+    public async Task GetRegistrationSubmissionDetails_ReturnsSuccess_WithValidSubmissionId()
+    {
+        // Arrange
+        var submissionId = Guid.Parse("0163A629-7780-445F-B00E-1898546BDF0C");
+        var organisationId = Guid.Parse("EE29CFAE-81AB-435F-8759-7285959530DB");
+
+        const string csoJsonWithoutMemberClosedLoopFlag =
+            "[{\"memberId\":\"100001\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"NumberOfSubsidiariesOnlineMarketPlace\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-10T07:24:00\",\"submissionPeriodDescription\":\"January to December 2025\"}]";
+
+        var mockData = CreateOrganisationRegistrationDetailsMock(submissionId, organisationId,
+            new OrganisationRegistrationDetailsMockVariation(
+                IsClosedLoopRecycler: null,
+                IsComplianceScheme: true,
+                OrganisationType: "compliance",
+                RegistrationJourney: "CsoLargeProducer",
+                OrganisationName: "Compliance Scheme Ltd",
+                OrganisationSize: null,
+                CompaniesHouseNumber: "CS123456",
+                CsoJson: csoJsonWithoutMemberClosedLoopFlag));
 
         SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
 
@@ -145,6 +174,102 @@ namespace IntegrationTests.Features
         var result = JsonSerializer.Deserialize<JsonElement>(content);
         result.GetProperty("submissionId").GetString().Should().Be(submissionId.ToString());
         result.GetProperty("organisationName").GetString().Should().Be("Compliance Scheme Ltd");
+    }
+
+    [Fact]
+    public async Task
+        GetRegistrationSubmissionDetails_FromCommonData_When_OrganisationIsClosedLoopRecyclerTrue_MapsResponseIsClosedLoopRecyclerTrue_ForDirectProducer()
+    {
+        var submissionId = Guid.Parse("1163A629-7780-445F-B00E-1898546BDF0C");
+        var organisationId = Guid.Parse("FE29CFAE-81AB-435F-8759-7285959530DB");
+
+        var mockData = CreateOrganisationRegistrationDetailsMock(submissionId, organisationId,
+            new OrganisationRegistrationDetailsMockVariation(
+                IsClosedLoopRecycler: true,
+                IsComplianceScheme: false,
+                OrganisationType: "Direct",
+                RegistrationJourney: "LargeProducer",
+                OrganisationName: "Direct Producer Ltd",
+                OrganisationSize: "Large",
+                CompaniesHouseNumber: "CH999999",
+                CsoJson: null));
+
+        SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
+
+        var response = await Client.GetAsync($"/api/organisation-registration-submission-details/{submissionId}");
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<JsonElement>(content);
+        result.GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task
+        GetRegistrationSubmissionDetails_WhenCsoMemberOmitsIsClosedLoopRecycler_AppliesOrganisationFlagToMember()
+    {
+        var submissionId = Guid.Parse("2263A629-7780-445F-B00E-1898546BDF0C");
+        var organisationId = Guid.Parse("AE29CFAE-81AB-435F-8759-7285959530DB");
+
+        const string csoJsonWithoutMemberClosedLoopFlag =
+            "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"NumberOfSubsidiariesOnlineMarketPlace\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-10T07:24:00\",\"submissionPeriodDescription\":\"January to December 2025\"}]";
+
+        var mockData = CreateOrganisationRegistrationDetailsMock(submissionId, organisationId,
+            new OrganisationRegistrationDetailsMockVariation(
+                IsClosedLoopRecycler: true,
+                IsComplianceScheme: true,
+                OrganisationType: "compliance",
+                RegistrationJourney: "CsoLargeProducer",
+                OrganisationName: "Compliance Scheme Ltd",
+                OrganisationSize: null,
+                CompaniesHouseNumber: "CS123456",
+                CsoJson: csoJsonWithoutMemberClosedLoopFlag));
+
+        SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
+
+        var response = await Client.GetAsync($"/api/organisation-registration-submission-details/{submissionId}");
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<JsonElement>(content);
+        result.GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeTrue();
+        var members = result.GetProperty("csoMembershipDetails");
+        members.GetArrayLength().Should().Be(1);
+        members[0].GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task
+        GetRegistrationSubmissionDetails_WhenCsoMemberSetsIsClosedLoopRecyclerFalse_DoesNotOverrideOrgTrueWithMemberFallback()
+    {
+        var submissionId = Guid.Parse("3363A629-7780-445F-B00E-1898546BDF0C");
+        var organisationId = Guid.Parse("BE29CFAE-81AB-435F-8759-7285959530DB");
+
+        const string csoJsonMemberExplicitFalse =
+            "[{\"memberId\":\"100003\",\"memberType\":\"large\",\"isClosedLoopRecycler\":false,\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":0,\"NumberOfSubsidiariesOnlineMarketPlace\":0,\"relevantYear\":2025,\"submittedDate\":\"2025-01-10T07:24:00\",\"submissionPeriodDescription\":\"January to December 2025\"}]";
+
+        var mockData = CreateOrganisationRegistrationDetailsMock(submissionId, organisationId,
+            new OrganisationRegistrationDetailsMockVariation(
+                IsClosedLoopRecycler: true,
+                IsComplianceScheme: true,
+                OrganisationType: "compliance",
+                RegistrationJourney: "CsoLargeProducer",
+                OrganisationName: "Compliance Scheme Ltd",
+                OrganisationSize: null,
+                CompaniesHouseNumber: "CS123456",
+                CsoJson: csoJsonMemberExplicitFalse));
+
+        SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
+
+        var response = await Client.GetAsync($"/api/organisation-registration-submission-details/{submissionId}");
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<JsonElement>(content);
+        result.GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeTrue();
+        var members = result.GetProperty("csoMembershipDetails");
+        members.GetArrayLength().Should().Be(1);
+        members[0].GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-136

- Adds the **`IsClosedLoopRecycling`** flag to organisation registration flows by extending Common Data DTOs (`OrganisationRegistrationDetailsDto`, `CSOMembershipDetailsDto`) and mapping it through **`CommonDataService`** into the façade response (`SubmissionOrganisationDetailsFacadeResponse`, name as in codebase).
- Renames the property from the earlier **`IsClosedLoopRecycler`** name to **`IsClosedLoopRecycling`** for consistency and updates deserialization/default handling accordingly.
- Adds unit coverage for DTO deserialization and service mapping behaviour around the new field.
