### PR TITLE
Add `NumberOfSubsidiariesClosedLoopRecycling` property

### DIFF
--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
@@ -16,6 +16,8 @@ public class CsoMembershipDetailsDto
 
     [JsonPropertyName("NumberOfSubsidiariesOnlineMarketPlace")]
     public int NoOfSubsidiariesOnlineMarketplace { get; set; }
+
+    public int NumberOfSubsidiariesClosedLoopRecycling { get; set; }
     public int RelevantYear { get; set; }
     public DateTime SubmittedDate { get;set; }
     public string SubmissionPeriodDescription {get;set;}

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/OrganisationRegistrationDetailsDto.cs
@@ -72,6 +72,7 @@ public class OrganisationRegistrationDetailsDto
     public bool IsOnlineMarketPlace { get; set; }
     public int NumberOfSubsidiaries { get; set; }
     public int NumberOfOnlineSubsidiaries { get; set; }
+    public int NumberOfSubsidiariesClosedLoopRecycling { get; set; }
 
     public Guid? CompanyDetailsFileId { get; set; }
     public string? CompanyDetailsFileName { get; set; }
@@ -183,6 +184,7 @@ public class OrganisationRegistrationDetailsDto
         response.IsOnlineMarketPlace = dto.IsOnlineMarketPlace;
         response.NumberOfSubsidiaries = dto.NumberOfSubsidiaries;
         response.NumberOfOnlineSubsidiaries = dto.NumberOfOnlineSubsidiaries;
+        response.NumberOfSubsidiariesClosedLoopRecycling = dto.NumberOfSubsidiariesClosedLoopRecycling;
         response.IsLateSubmission = dto.IsLateSubmission;
 
         // Creating and assigning SubmissionDetails

--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/RegistrationSubmissionOrganisationDetailsFacadeResponse.cs
@@ -57,6 +57,7 @@ public class RegistrationSubmissionOrganisationDetailsFacadeResponse
     public bool IsOnlineMarketPlace { get; internal set; }
     public int NumberOfSubsidiaries { get; internal set; }
     public int NumberOfOnlineSubsidiaries { get; internal set; }
+    public int NumberOfSubsidiariesClosedLoopRecycling { get; set; }
     public bool IsLateSubmission { get; internal set; }
     public string OrganisationSize { get; internal set; }
     public bool IsComplianceScheme { get; internal set; }

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Models/OrganisationRegistrationDetailsDtoTests.cs
@@ -67,11 +67,46 @@ public class OrganisationRegistrationDetailsDtoTests
             RegistrationJourney = "LargeProducer",
             NationId = 1,
             NationCode = "GB-ENG",
-            IsClosedLoopRecycler = true
+            IsClosedLoopRecycler = true,
+            NumberOfSubsidiariesClosedLoopRecycling = 7
         };
 
         var response = (RegistrationSubmissionOrganisationDetailsFacadeResponse)dto;
 
         response.IsClosedLoopRecycler.Should().BeTrue();
+        response.NumberOfSubsidiariesClosedLoopRecycling.Should().Be(7);
+    }
+
+    [TestMethod]
+    public void Deserialize_FromCommonDataApi_Maps_NumberOfSubsidiariesClosedLoopRecycling_FromJson()
+    {
+        const string json = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "Test Org",
+              "organisationReference": "100001",
+              "applicationReferenceNumber": "REG-2025-001",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "numberOfSubsidiariesClosedLoopRecycling": 4,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": false,
+              "organisationSize": "Large",
+              "organisationType": "Direct",
+              "registrationJourney": "LargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG"
+            }
+            """;
+
+        var dto = JsonSerializer.Deserialize<OrganisationRegistrationDetailsDto>(json, DeserialisationOptions);
+
+        dto.Should().NotBeNull();
+        dto!.NumberOfSubsidiariesClosedLoopRecycling.Should().Be(4);
     }
 }

--- a/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
+++ b/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
@@ -71,7 +71,8 @@ namespace IntegrationTests.Features
         string OrganisationName,
         string? OrganisationSize,
         string? CompaniesHouseNumber,
-        string? CsoJson);
+        string? CsoJson,
+        int NumberOfSubsidiariesClosedLoopRecycling = 0);
 
     // Common Data organisation-registration payload shape (camelCase anon-type properties match WireMock JSON).
     private static object CreateOrganisationRegistrationDetailsMock(Guid submissionId, Guid organisationId, OrganisationRegistrationDetailsMockVariation variation)
@@ -129,6 +130,7 @@ namespace IntegrationTests.Features
             isOnlineMarketPlace = false,
             numberOfSubsidiaries = 0,
             numberOfOnlineSubsidiaries = 0,
+            numberOfSubsidiariesClosedLoopRecycling = variation.NumberOfSubsidiariesClosedLoopRecycling,
             companyDetailsFileId = "F1A2B3C4-D5E6-7890-ABCD-EF1234567890",
             companyDetailsFileName = "reg-20250110_093000.csv",
             companyDetailsBlobName = "B1C2D3E4-F5A6-7890-ABCD-EF1234567890",
@@ -192,7 +194,8 @@ namespace IntegrationTests.Features
                 OrganisationName: "Direct Producer Ltd",
                 OrganisationSize: "Large",
                 CompaniesHouseNumber: "CH999999",
-                CsoJson: null));
+                CsoJson: null,
+                NumberOfSubsidiariesClosedLoopRecycling: 12));
 
         SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
 
@@ -202,6 +205,40 @@ namespace IntegrationTests.Features
         var content = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<JsonElement>(content);
         result.GetProperty("isClosedLoopRecycler").GetBoolean().Should().BeTrue();
+        result.GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(12);
+    }
+
+    [Fact]
+    public async Task
+        GetRegistrationSubmissionDetails_WhenCsoMemberIncludesClosedLoopSubsidiaryCount_MapsToCsoMembershipDetails()
+    {
+        var submissionId = Guid.Parse("4463A629-7780-445F-B00E-1898546BDF0C");
+        var organisationId = Guid.Parse("CE29CFAE-81AB-435F-8759-7285959530DB");
+
+        const string csoJsonWithClosedLoopSubsidiaryCount =
+            "[{\"memberId\":\"100004\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":5,\"NumberOfSubsidiariesOnlineMarketPlace\":0,\"NumberOfSubsidiariesClosedLoopRecycling\":3,\"relevantYear\":2025,\"submittedDate\":\"2025-01-10T07:24:00\",\"submissionPeriodDescription\":\"January to December 2025\"}]";
+
+        var mockData = CreateOrganisationRegistrationDetailsMock(submissionId, organisationId,
+            new OrganisationRegistrationDetailsMockVariation(
+                IsClosedLoopRecycler: true,
+                IsComplianceScheme: true,
+                OrganisationType: "compliance",
+                RegistrationJourney: "CsoLargeProducer",
+                OrganisationName: "Compliance Scheme Ltd",
+                OrganisationSize: null,
+                CompaniesHouseNumber: "CS123456",
+                CsoJson: csoJsonWithClosedLoopSubsidiaryCount));
+
+        SetupCommonDataMockOrganisationRegistrationDetails(submissionId, mockData);
+
+        var response = await Client.GetAsync($"/api/organisation-registration-submission-details/{submissionId}");
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<JsonElement>(content);
+        var members = result.GetProperty("csoMembershipDetails");
+        members.GetArrayLength().Should().Be(1);
+        members[0].GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(3);
     }
 
     [Fact]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-238

Expose subsidiary closed-loop recycling counts for regulator registration payment details

- Common Data (epr-common-data-api): Count subsidiaries with closed_loop_registration = 'YES' in paycal parameters and surface NumberOfSubsidiariesClosedLoopRecycling on organisation registration submission details (direct producers and CSO csoJson). Includes view, materialised table, merge, and stored procedure updates.
- Regulator facade (epr-regulator-service-facade): Map numberOfSubsidiariesClosedLoopRecycling and isClosedLoopRecycler from Common Data through to the organisation registration submission details API, including CSO membership details.
- Enables the regulator frontend to pass subsidiary CLR counts to the payment facade so subsidiary closed-loop recycling fees display correctly for large direct producers (and CSO members where applicable).