### PR TITLE
Amcr 298 display correct clr fees for subsidiaries

### DIFF
--- a/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Models/Responses/OrganisationRegistrations/CommonData/CSOMembershipDetailsDto.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 
 namespace EPR.RegulatorService.Facade.Core.Models.Responses.OrganisationRegistrations.CommonData;
 
@@ -10,11 +9,11 @@ public class CsoMembershipDetailsDto
     public string MemberType { get; set; }
     public bool IsOnlineMarketPlace { get; set; }
     public bool IsLateFeeApplicable { get; set; }
+    public bool IsClosedLoopRecycling { get; set; }
 
     public int NumberOfSubsidiaries { get; set; }
 
-    [JsonPropertyName("NumberOfSubsidiariesOnlineMarketPlace")]
-    public int NoOfSubsidiariesOnlineMarketplace { get; set; }
+    public int NumberOfSubsidiariesOnlineMarketPlace { get; set; }
 
     public int? NumberOfHoldingCompaniesClosedLoopRecycling { get; set; }
     public int? NumberOfSubsidiariesClosedLoopRecycling { get; set; }

--- a/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
+++ b/src/EPR.RegulatorService.Facade.Core/Services/CommonData/CommonDataService.cs
@@ -154,13 +154,9 @@ public class CommonDataService(
         {
             try
             {
-                List<CsoMembershipDetailsDto> csoDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(jsonObject.CSOJson, _deserialisationOptions);
-                foreach (var member in csoDetails)
-                {
-                    member.NumberOfHoldingCompaniesClosedLoopRecycling ??= jsonObject.NumberOfHoldingCompaniesClosedLoopRecycling;
-                    member.NumberOfSubsidiariesClosedLoopRecycling ??= jsonObject.NumberOfSubsidiariesClosedLoopRecycling;
-                }
-                objRet.CsoMembershipDetails = csoDetails;
+                objRet.CsoMembershipDetails = JsonSerializer.Deserialize<List<CsoMembershipDetailsDto>>(
+                    jsonObject.CSOJson,
+                    _deserialisationOptions);
             }
             catch (Exception ex)
             {

--- a/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
+++ b/src/EPR.RegulatorService.Facade.UnitTests/Core/Services/CommonData/CommonDataServiceTests.cs
@@ -269,7 +269,88 @@ public class CommonDataServiceTests
     }
 
     [TestMethod]
-    public async Task Should_map_common_data_NumberOfSubsidiariesClosedLoopRecycling_and_apply_cso_member_fallback()
+    public async Task Should_deserialize_cso_member_IsClosedLoopRecycling_from_csoJson()
+    {
+        var submissionId = Guid.NewGuid();
+        _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
+
+        const string commonDataJson = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "CSO Producer",
+              "organisationReference": "100002",
+              "applicationReferenceNumber": "REG-2025-002",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "numberOfSubsidiariesClosedLoopRecycling": 5,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": true,
+              "organisationSize": "Large",
+              "organisationType": "compliance",
+              "registrationJourney": "CsoLargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG",
+              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isClosedLoopRecycling\":true,\"numberOfSubsidiariesClosedLoopRecycling\":2,\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":3,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
+            }
+            """;
+
+        SetupApiSuccessCall(commonDataJson);
+
+        var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
+
+        results.Should().NotBeNull();
+        results!.NumberOfSubsidiariesClosedLoopRecycling.Should().Be(5);
+        results.CsoMembershipDetails.Should().HaveCount(1);
+        results.CsoMembershipDetails![0].IsClosedLoopRecycling.Should().BeTrue();
+        results.CsoMembershipDetails[0].NumberOfSubsidiariesClosedLoopRecycling.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task Should_deserialize_cso_member_NumberOfSubsidiariesOnlineMarketPlace_from_csoJson()
+    {
+        var submissionId = Guid.NewGuid();
+        _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
+
+        const string commonDataJson = """
+            {
+              "submissionId": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+              "organisationId": "2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+              "organisationName": "CSO Producer",
+              "organisationReference": "100002",
+              "applicationReferenceNumber": "REG-2025-002",
+              "submissionStatus": "Granted",
+              "submittedDateTime": "2025-01-11T10:30:00Z",
+              "isLateSubmission": false,
+              "submissionPeriod": "2025",
+              "relevantYear": 2025,
+              "isResubmission": false,
+              "resubmissionStatus": "Pending",
+              "isComplianceScheme": true,
+              "organisationSize": "Large",
+              "organisationType": "compliance",
+              "registrationJourney": "CsoLargeProducer",
+              "nationId": 1,
+              "nationCode": "GB-ENG",
+              "csoJson": "[{\"memberId\":\"100002\",\"memberType\":\"large\",\"isOnlineMarketPlace\":false,\"isLateFeeApplicable\":true,\"numberOfSubsidiaries\":2,\"NumberOfSubsidiariesOnlineMarketPlace\":1,\"relevantYear\":2025,\"submittedDate\":\"2025-01-11T08:24:00\",\"submissionPeriodDescription\":\"2025\"}]"
+            }
+            """;
+
+        SetupApiSuccessCall(commonDataJson);
+
+        var results = await _sut.GetOrganisationRegistrationSubmissionDetails(submissionId);
+
+        results.Should().NotBeNull();
+        results!.CsoMembershipDetails.Should().HaveCount(1);
+        results.CsoMembershipDetails![0].NumberOfSubsidiariesOnlineMarketPlace.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task Should_not_apply_org_level_subsidiary_clr_fallback_to_cso_members()
     {
         var submissionId = Guid.NewGuid();
         _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
@@ -306,11 +387,11 @@ public class CommonDataServiceTests
         results.Should().NotBeNull();
         results!.NumberOfSubsidiariesClosedLoopRecycling.Should().Be(5);
         results.CsoMembershipDetails.Should().HaveCount(1);
-        results.CsoMembershipDetails![0].NumberOfSubsidiariesClosedLoopRecycling.Should().Be(5);
+        results.CsoMembershipDetails![0].NumberOfSubsidiariesClosedLoopRecycling.Should().BeNull();
     }
 
     [TestMethod]
-    public async Task Should_map_common_data_NumberOfHoldingCompaniesClosedLoopRecycling_and_apply_cso_member_fallback()
+    public async Task Should_not_apply_org_level_hc_clr_fallback_to_cso_members()
     {
         var submissionId = Guid.NewGuid();
         _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";
@@ -347,11 +428,12 @@ public class CommonDataServiceTests
         results.Should().NotBeNull();
         results!.NumberOfHoldingCompaniesClosedLoopRecycling.Should().Be(2);
         results.CsoMembershipDetails.Should().HaveCount(1);
-        results.CsoMembershipDetails![0].NumberOfHoldingCompaniesClosedLoopRecycling.Should().Be(2);
+        results.CsoMembershipDetails![0].NumberOfHoldingCompaniesClosedLoopRecycling.Should().BeNull();
+        results.CsoMembershipDetails[0].IsClosedLoopRecycling.Should().BeFalse();
     }
 
     [TestMethod]
-    public async Task Should_not_override_explicit_zero_cso_member_closed_loop_subsidiary_count()
+    public async Task Should_preserve_explicit_zero_cso_member_closed_loop_subsidiary_count()
     {
         var submissionId = Guid.NewGuid();
         _expectedUrl = $"{BaseAddress}/{_configuration.Value.Endpoints.GetOrganisationRegistrationSubmissionDetails}/{submissionId}";

--- a/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
+++ b/src/IntegrationTests/Features/OrganisationRegistrationSubmissionsTests.cs
@@ -241,7 +241,7 @@ namespace IntegrationTests.Features
 
     [Fact]
     public async Task
-        GetRegistrationSubmissionDetails_WhenCsoMemberOmitsClosedLoopSubsidiaryCount_AppliesOrganisationCountToMember()
+        GetRegistrationSubmissionDetails_WhenCsoMemberOmitsClosedLoopCounts_DoesNotApplyOrganisationCountsToMember()
     {
         var submissionId = Guid.Parse("2263A629-7780-445F-B00E-1898546BDF0C");
         var organisationId = Guid.Parse("AE29CFAE-81AB-435F-8759-7285959530DB");
@@ -272,13 +272,13 @@ namespace IntegrationTests.Features
         result.GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(7);
         var members = result.GetProperty("csoMembershipDetails");
         members.GetArrayLength().Should().Be(1);
-        members[0].GetProperty("numberOfHoldingCompaniesClosedLoopRecycling").GetInt32().Should().Be(2);
-        members[0].GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(7);
+        members[0].GetProperty("numberOfHoldingCompaniesClosedLoopRecycling").ValueKind.Should().Be(JsonValueKind.Null);
+        members[0].GetProperty("numberOfSubsidiariesClosedLoopRecycling").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     [Fact]
     public async Task
-        GetRegistrationSubmissionDetails_WhenCsoMemberSetsClosedLoopSubsidiaryCountZero_DoesNotOverrideOrgCountWithMemberFallback()
+        GetRegistrationSubmissionDetails_WhenCsoMemberSetsClosedLoopSubsidiaryCountZero_PreservesExplicitZeroWithoutOrgFallback()
     {
         var submissionId = Guid.Parse("3363A629-7780-445F-B00E-1898546BDF0C");
         var organisationId = Guid.Parse("BE29CFAE-81AB-435F-8759-7285959530DB");
@@ -309,7 +309,7 @@ namespace IntegrationTests.Features
         result.GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(7);
         var members = result.GetProperty("csoMembershipDetails");
         members.GetArrayLength().Should().Be(1);
-        members[0].GetProperty("numberOfHoldingCompaniesClosedLoopRecycling").GetInt32().Should().Be(2);
+        members[0].GetProperty("numberOfHoldingCompaniesClosedLoopRecycling").ValueKind.Should().Be(JsonValueKind.Null);
         members[0].GetProperty("numberOfSubsidiariesClosedLoopRecycling").GetInt32().Should().Be(0);
     }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-298

**What**
- Fixes incorrect closed-loop recycling (CLR) and subsidiary online marketplace (OMP) data mapping for CSO compliance scheme members in organisation registration submission details.
- Adds IsClosedLoopRecycling to CsoMembershipDetailsDto so holding-company CLR flags are preserved when deserialising csoJson.
- Renames NoOfSubsidiariesOnlineMarketplace to NumberOfSubsidiariesOnlineMarketPlace so subsidiary OMP counts serialise as numberOfSubsidiariesOnlineMarketPlace and bind correctly to the regulator frontend DTO (previously always resolved to 0).
- Removes org-level CLR fallback in CommonDataService that copied NumberOfHoldingCompaniesClosedLoopRecycling and NumberOfSubsidiariesClosedLoopRecycling onto CSO members when member-level values were absent.
- Adds unit tests for deserialising IsClosedLoopRecycling and NumberOfSubsidiariesOnlineMarketPlace from csoJson, and updates integration tests to assert member-only CLR mapping.

**Why**
- For CSO submissions with multiple members, holding-company CLR and subsidiary OMP fees were missing or incorrect in the regulator payment request. The facade was dropping IsClosedLoopRecycling from csoJson, misnaming the subsidiary OMP property so the frontend never received the count, and applying organisation-level CLR counts to members that had no member-level CLR data. Mapping only the values present on each CSO member aligns the facade response with submitted registration data and allows the regulator frontend to request the correct payment fees.